### PR TITLE
Fix the end quote character for correct formatting of GET request

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -37,4 +37,4 @@ building 'zwei' edge-gateway ........................ done.
 
 * `POST /api/sessions`
 * `POST /api/org`
-* `GET /api/org/:vorg_urn'
+* `GET /api/org/:vorg_urn`


### PR DESCRIPTION
The end quote character is not the correct one for the GET line to be formatted correctly.  This pull request fixes that.