### PR TITLE
Use Ubuntu 20.04 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY --from=web-compiler /app/dist/ /app/dist
 RUN touch /app/dist/*
 RUN cargo build --release
 
-FROM ubuntu:19.10
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install --assume-yes ca-certificates
 COPY --from=server-compiler /app/server/target/release/server /server
 ENTRYPOINT ["/server", "0.0.0.0:3000"]


### PR DESCRIPTION
Ubuntu 19.10 gave the following error:

```
Step 22/26 : RUN apt-get update && apt-get install --assume-yes ca-certificates
 ---> Running in ac9cf9f8e189
Ign:1 http://archive.ubuntu.com/ubuntu eoan InRelease
Ign:2 http://archive.ubuntu.com/ubuntu eoan-updates InRelease
Ign:3 http://archive.ubuntu.com/ubuntu eoan-backports InRelease
Err:4 http://archive.ubuntu.com/ubuntu eoan Release
  404  Not Found [IP: 91.189.88.142 80]
Err:5 http://archive.ubuntu.com/ubuntu eoan-updates Release
  404  Not Found [IP: 91.189.88.142 80]
Err:6 http://archive.ubuntu.com/ubuntu eoan-backports Release
  404  Not Found [IP: 91.189.88.142 80]
Ign:7 http://security.ubuntu.com/ubuntu eoan-security InRelease
Err:8 http://security.ubuntu.com/ubuntu eoan-security Release
  404  Not Found [IP: 91.189.91.39 80]
Reading package lists...
E: The repository 'http://archive.ubuntu.com/ubuntu eoan Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-updates Release' does not have a Release file.
E: The repository 'http://archive.ubuntu.com/ubuntu eoan-backports Release' does not have a Release file.
E: The repository 'http://security.ubuntu.com/ubuntu eoan-security Release' does not have a Release file.
The command '/bin/sh -c apt-get update && apt-get install --assume-yes ca-certificates' returned a non-zero code: 100
```